### PR TITLE
Fix typo in ReadUIntBase128 pseudo-code.

### DIFF
--- a/woff2/index.html
+++ b/woff2/index.html
@@ -396,7 +396,7 @@
             UInt8 data_byte = data.getNextUInt8();
 
             // No leading 0's
-            if (i == 0 &amp;&amp; data_byte = 0x80) return false;
+            if (i == 0 &amp;&amp; data_byte == 0x80) return false;
 
             // If any of top 7 bits are set then &lt;&lt; 7 would overflow
             if (accum &amp; 0xFE000000) return false;


### PR DESCRIPTION
The assignment operator was being used instead of equality operator.